### PR TITLE
Add panic level logging

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"strings"
 )
 
 //Logger is the interface for the objects that are the target of logging messages. Logging methods
@@ -539,6 +540,13 @@ func (logger *LoggerImpl) logwithformat(level LogLevel, tags []string, format st
 		msg = fmt.Sprint(args...)
 	} else {
 		msg = fmt.Sprintf(format, args...)
+	}
+
+	if level == PANIC {
+		stack := make([]byte, 10 * 1024)
+		size := runtime.Stack(stack, false)
+		stackStr := strings.Replace(string(stack[:size]), "\n", "\n  ", -1)
+		msg = msg + "\n  " + stackStr
 	}
 
 	logRecord := NewLogRecord(logger, level, tags, msg, now, now)

--- a/logging.go
+++ b/logging.go
@@ -23,6 +23,11 @@ import (
 //Logger is the interface for the objects that are the target of logging messages. Logging methods
 //imply a level. For example, Info() implies a level of LogLevel.INFO.
 type Logger interface {
+	PanicWithTagsf(tags []string, fmt string, args ...interface{})
+	PanicWithTags(tags []string, args ...interface{})
+	Panicf(fmt string, args ...interface{})
+	Panic(args ...interface{})
+
 	ErrorWithTagsf(tags []string, fmt string, args ...interface{})
 	ErrorWithTags(tags []string, args ...interface{})
 	Errorf(fmt string, args ...interface{})
@@ -177,6 +182,18 @@ func WaitForIncoming() {
 	for {
 		if atomic.LoadUint64(&processed) != atomic.LoadUint64(&logged) {
 			time.Sleep(2 * time.Millisecond)
+		} else {
+			return
+		}
+	}
+}
+
+//Waits for the specific log to be processed
+func WaitForProcessed(logNum uint64) {
+	runtime.Gosched() //start by giving the other go routines a chance to run
+	for {
+		if logNum != atomic.LoadUint64(&processed) {
+			time.Sleep(1 * time.Millisecond)
 		} else {
 			return
 		}
@@ -509,10 +526,10 @@ func (logger *LoggerImpl) flushBuffer(wait *sync.WaitGroup) {
 	}
 }
 
-func (logger *LoggerImpl) logwithformat(level LogLevel, tags []string, format string, args ...interface{}) {
+func (logger *LoggerImpl) logwithformat(level LogLevel, tags []string, format string, args ...interface{}) uint64 {
 
 	if level == VERBOSE && atomic.LoadInt32(&enableVerbose) != 1 {
-		return
+		return 0
 	}
 
 	now := time.Now()
@@ -525,12 +542,115 @@ func (logger *LoggerImpl) logwithformat(level LogLevel, tags []string, format st
 	}
 
 	logRecord := NewLogRecord(logger, level, tags, msg, now, now)
-	atomic.AddUint64(&logged, 1)
+	logNum := atomic.AddUint64(&logged, 1)
 	incomingChannel <- logRecord
+
+	//return the logged number to track if it was processed
+	return logNum
 }
 
-func (logger *LoggerImpl) log(level LogLevel, tags []string, args ...interface{}) {
-	logger.logwithformat(level, tags, "", args...)
+func (logger *LoggerImpl) log(level LogLevel, tags []string, args ...interface{}) uint64{
+	return logger.logwithformat(level, tags, "", args...)
+}
+
+//PanicWithTagsf logs a PANIC level message with the provided tags and formatted string.
+func (logger *LoggerImpl) PanicWithTagsf(tags []string, format string, args ...interface{}) {
+	logNum := logger.logwithformat(PANIC, tags, format, args...)
+
+	//ensure the panic message we just logged gets processed
+	WaitForProcessed(logNum)
+
+	//flush all logs before panicking
+	logMutex.Lock()
+	wait := new(sync.WaitGroup)
+	if logger == defaultLogger {
+		flushAllLoggers(wait)
+	} else {
+		wait.Add(1)
+		logger.flushBuffer(wait)
+	}
+	logMutex.Unlock()
+	wait.Wait()
+
+	//continue with the panic
+	if format == "" {
+		panic(fmt.Sprint(args...))
+	} else {
+		panic(fmt.Sprintf(format, args...))
+	}
+}
+
+//PanicWithTags logs a PANIC level message with the provided tags and provided arguments joined into a string.
+func (logger *LoggerImpl) PanicWithTags(tags []string, args ...interface{}) {
+	logNum := logger.log(PANIC, tags, args...)
+
+	//ensure the panic message we just logged gets processed
+	WaitForProcessed(logNum)
+
+	//flush all logs before panicking
+	logMutex.Lock()
+	wait := new(sync.WaitGroup)
+	if logger == defaultLogger {
+		flushAllLoggers(wait)
+	} else {
+		wait.Add(1)
+		logger.flushBuffer(wait)
+	}
+	logMutex.Unlock()
+	wait.Wait()
+
+	//continue with panic
+	panic(fmt.Sprint(args...))
+}
+
+//Panicf logs a PANIC level message with the no tags and formatted string.
+func (logger *LoggerImpl) Panicf(format string, args ...interface{}) {
+	logNum := logger.logwithformat(PANIC, nil, format, args...)
+
+	//ensure the panic message we just logged gets processed
+	WaitForProcessed(logNum)
+
+	//flush all logs before panicking
+	logMutex.Lock()
+	wait := new(sync.WaitGroup)
+	if logger == defaultLogger {
+		flushAllLoggers(wait)
+	} else {
+		wait.Add(1)
+		logger.flushBuffer(wait)
+	}
+	logMutex.Unlock()
+	wait.Wait()
+
+	//continue with the panic
+	if format == "" {
+		panic(fmt.Sprint(args...))
+	} else {
+		panic(fmt.Sprintf(format, args...))
+	}
+}
+
+//Panic logs a PANIC level message with no tags and provided arguments joined into a string.
+func (logger *LoggerImpl) Panic(args ...interface{}) {
+	logNum := logger.log(PANIC, nil, args...)
+
+	//ensure the panic message we just logged gets processed
+	WaitForProcessed(logNum)
+
+	//flush all logs before panicking
+	logMutex.Lock()
+	wait := new(sync.WaitGroup)
+	if logger == defaultLogger {
+		flushAllLoggers(wait)
+	} else {
+		wait.Add(1)
+		logger.flushBuffer(wait)
+	}
+	logMutex.Unlock()
+	wait.Wait()
+
+	//continue with the panic
+	panic(fmt.Sprint(args...))
 }
 
 //ErrorWithTagsf logs an ERROR level message with the provided tags and formatted string.

--- a/logging_test.go
+++ b/logging_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -293,7 +294,14 @@ func TestPanicLogging(t *testing.T) {
 		assert.Equal(t, memory.GetLoggedMessages()[5], "[INFO] [blit blat] one 1", "messages should be formatted")
 		assert.Equal(t, memory.GetLoggedMessages()[6], "[DEBUG] [blit blat] one", "unformatted messages should be unchanged")
 		assert.Equal(t, memory.GetLoggedMessages()[7], "[DEBUG] [blit blat] one 1", "messages should be formatted")
-		assert.Equal(t, memory.GetLoggedMessages()[8], "[PANIC] [blit blat] panic", "unformatted messages should be unchanged")
+
+		msgWithStack := strings.Split(memory.GetLoggedMessages()[8], "\n")
+
+		assert.Equal(t, msgWithStack[0], "[PANIC] [blit blat] panic", "unformatted messages should be unchanged")
+		assert.True(t, len(msgWithStack) > 1, "panic messages should include stack trace")
+		for i := 1; i < len(msgWithStack); i++ {
+			assert.Equal(t, "  ", msgWithStack[i][0:2], "every stack trace line should be indented two spaces")
+		}
 
 	}()
 
@@ -333,8 +341,14 @@ func TestPanicFormatLogging(t *testing.T) {
 		assert.Equal(t, memory.GetLoggedMessages()[5], "[INFO] [blit blat] one 1", "messages should be formatted")
 		assert.Equal(t, memory.GetLoggedMessages()[6], "[DEBUG] [blit blat] one", "unformatted messages should be unchanged")
 		assert.Equal(t, memory.GetLoggedMessages()[7], "[DEBUG] [blit blat] one 1", "messages should be formatted")
-		assert.Equal(t, memory.GetLoggedMessages()[8], "[PANIC] [blit blat] panic 1", "messages should be formatted")
 
+		msgWithStack := strings.Split(memory.GetLoggedMessages()[8], "\n")
+
+		assert.Equal(t, msgWithStack[0], "[PANIC] [blit blat] panic 1", "messages should be formatted")
+		assert.True(t, len(msgWithStack) > 1, "panic messages should include stack trace")
+		for i := 1; i < len(msgWithStack); i++ {
+			assert.Equal(t, "  ", msgWithStack[i][0:2], "every stack trace line should be indented two spaces")
+		}
 	}()
 
 	logger.ErrorWithTags(tags, "one")

--- a/loglevel.go
+++ b/loglevel.go
@@ -17,13 +17,17 @@ const (
 	INFO
 	//WARN is provided for warnings that do not represent a major program error
 	WARN
-	//ERROR is the highest log level and should only be used for exceptional conditions
+	//ERROR is should only be used for exceptional conditions
 	ERROR
+	//The highest log level only to be used when logging a panic
+	PANIC
 )
 
 //String converts a log level to an upper case string
 func (level LogLevel) String() string {
 	switch {
+	case level >= PANIC:
+		return "PANIC"
 	case level >= ERROR:
 		return "ERROR"
 	case level >= WARN:
@@ -45,6 +49,8 @@ func LevelFromString(str string) LogLevel {
 	str = strings.ToLower(str)
 
 	switch str {
+	case "panic":
+		return PANIC
 	case "error":
 		return ERROR
 	case "warning", "warn":

--- a/loglevel_test.go
+++ b/loglevel_test.go
@@ -11,14 +11,15 @@ func TestLevelToString(t *testing.T) {
 	assert.Equal(t, INFO.String(), "INFO", "INFO.String() = %v, want %v", INFO, "INFO")
 	assert.Equal(t, WARN.String(), "WARN", "WARN.String() = %v, want %v", WARN, "WARN")
 	assert.Equal(t, ERROR.String(), "ERROR", "ERROR.String() = %v, want %v", ERROR, "ERROR")
+	assert.Equal(t, PANIC.String(), "PANIC", "PANIC.String() = %v, want %v", PANIC, "PANIC")
 	assert.Equal(t, VERBOSE.String(), "VERBOSE", "VERBOSE.String() = %v, want %v", VERBOSE, "VERBOSE")
 	assert.Equal(t, LogLevel(0).String(), "VERBOSE", "VERBOSE.String() = %v, want %v", VERBOSE, "VERBOSE")
 }
 
 func TestFromString(t *testing.T) {
 
-	levelStrings := []string{"debug", "Debug", "warn", "Warning", "error", "INFO", "Informative", "verBose", "none"}
-	levels := []LogLevel{DEBUG, DEBUG, WARN, WARN, ERROR, INFO, INFO, VERBOSE, DEFAULT}
+	levelStrings := []string{"debug", "Debug", "warn", "Warning", "error", "Panic", "INFO", "Informative", "verBose", "none"}
+	levels := []LogLevel{DEBUG, DEBUG, WARN, WARN, ERROR, PANIC, INFO, INFO, VERBOSE, DEFAULT}
 
 	for i, levelString := range levelStrings {
 		level := levels[i]


### PR DESCRIPTION
Hello,

First let me say that we love this library.  Being able to turn verbose logging on by tag at runtime is a huge win for us.  Now to the issue we're trying to solve.

We found that if we panic right after we log.Error, our error log was not ending up in our logs.  This was because we were not waiting sufficiently for all the log entries to be processed before panicking.  So, we've forked the library in order to add a log.Panic function, which will wait until the panic log message has been processed and written to the appenders before panicking.
